### PR TITLE
Adapt to missing scan and id persistence features in intiface-engine

### DIFF
--- a/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
@@ -86,6 +86,7 @@ export default class ButtplugIoDeviceFactory
     private createKnownDevice(buttplugDevice: ButtplugClientDevice, provider: string, useDeviceNameAsId: boolean): KnownDevice {
         // Since we don't get a unique identifier for the Bluetooth device from Intiface,
         // we need to use the index assigned to the device by Intiface. It's the best we have.
+        // or the name if using Intiface-engine without id persistence
         const nameString = buttplugDevice.name.replace(/[^a-zA-Z0-9]/g, '');
         const deviceId = useDeviceNameAsId ? `buttplugio-${nameString}` : `buttplugio-${buttplugDevice.index}`;
 

--- a/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
@@ -21,7 +21,7 @@ export default class ButtplugIoDeviceFactory
 
     private readonly logger: Logger;
 
-    private readonly useNameAsSerial: boolean
+    private useNameAsSerial: boolean
 
     public constructor(uuidFactory: UuidFactory, dateFactory: DateFactory, settings: Settings, logger: Logger) {
         this.uuidFactory = uuidFactory;
@@ -31,14 +31,12 @@ export default class ButtplugIoDeviceFactory
 
         this.useNameAsSerial = false;
         const configuredDeviceSources = this.settings.getDeviceSources();
-        for (const [id, deviceSource] of configuredDeviceSources) {
-            if (deviceSource.type === 'buttplugIoWebsocket' && deviceSource.config?.useNameAsSerial) {
-                this.logger.info(`Device source ${deviceSource.type} using names as serial`);
+        configuredDeviceSources.forEach((value) => {
+            if (value.type === 'buttplugIoWebsocket' && value.config?.useNameAsSerial) {
+                this.logger.debug(`Device source ${value.type} using names as serial`);
                 this.useNameAsSerial = true;
             }
-        }
-
-
+        });
     }
 
     public create(buttplugDevice: ButtplugClientDevice, provider: string): ButtplugIoDevice {

--- a/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
@@ -21,7 +21,7 @@ export default class ButtplugIoDeviceFactory
 
     private readonly logger: Logger;
 
-    private useNameAsSerial: boolean
+    private useDeviceNameAsId: boolean
 
     public constructor(uuidFactory: UuidFactory, dateFactory: DateFactory, settings: Settings, logger: Logger) {
         this.uuidFactory = uuidFactory;
@@ -29,12 +29,12 @@ export default class ButtplugIoDeviceFactory
         this.settings = settings;
         this.logger = logger;
 
-        this.useNameAsSerial = false;
+        this.useDeviceNameAsId = false;
         const configuredDeviceSources = this.settings.getDeviceSources();
         configuredDeviceSources.forEach((value) => {
-            if (value.type === 'buttplugIoWebsocket' && value.config?.useNameAsSerial) {
+            if (value.type === 'buttplugIoWebsocket' && true === value.config?.useDeviceNameAsId) {
                 this.logger.debug(`Device source ${value.type} using names as serial`);
-                this.useNameAsSerial = true;
+                this.useDeviceNameAsId = true;
             }
         });
     }
@@ -98,7 +98,7 @@ export default class ButtplugIoDeviceFactory
         // Since we don't get a unique identifier for the Bluetooth device from Intiface,
         // we need to use the index assigned to the device by Intiface. It's the best we have.
         const nameString = buttplugDevice.name.replace(/[^a-zA-Z0-9]/g, '');
-        const deviceId = this.useNameAsSerial ? `buttplugio-${nameString}` : `buttplugio-${buttplugDevice.index}`;
+        const deviceId = this.useDeviceNameAsId ? `buttplugio-${nameString}` : `buttplugio-${buttplugDevice.index}`;
 
         let knownDevice = this.settings.getKnownDeviceById(deviceId)
 

--- a/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
@@ -21,26 +21,15 @@ export default class ButtplugIoDeviceFactory
 
     private readonly logger: Logger;
 
-    private useDeviceNameAsId: boolean
-
     public constructor(uuidFactory: UuidFactory, dateFactory: DateFactory, settings: Settings, logger: Logger) {
         this.uuidFactory = uuidFactory;
         this.dateFactory = dateFactory;
         this.settings = settings;
         this.logger = logger;
-
-        this.useDeviceNameAsId = false;
-        const configuredDeviceSources = this.settings.getDeviceSources();
-        configuredDeviceSources.forEach((value) => {
-            if (value.type === 'buttplugIoWebsocket' && true === value.config?.useDeviceNameAsId) {
-                this.logger.debug(`Device source ${value.type} using names as serial`);
-                this.useDeviceNameAsId = true;
-            }
-        });
     }
 
-    public create(buttplugDevice: ButtplugClientDevice, provider: string): ButtplugIoDevice {
-        const knownDevice = this.createKnownDevice(buttplugDevice, provider);
+    public create(buttplugDevice: ButtplugClientDevice, provider: string, useDeviceNameAsId: boolean): ButtplugIoDevice {
+        const knownDevice = this.createKnownDevice(buttplugDevice, provider, useDeviceNameAsId);
 
         const deviceAttrs = ButtplugIoDeviceFactory.parseDeviceAttributes(buttplugDevice);
 
@@ -94,7 +83,7 @@ export default class ButtplugIoDeviceFactory
         return attributeList;
     }
 
-    private createKnownDevice(buttplugDevice: ButtplugClientDevice, provider: string): KnownDevice {
+    private createKnownDevice(buttplugDevice: ButtplugClientDevice, provider: string, useDeviceNameAsId: boolean): KnownDevice {
         // Since we don't get a unique identifier for the Bluetooth device from Intiface,
         // we need to use the index assigned to the device by Intiface. It's the best we have.
         const nameString = buttplugDevice.name.replace(/[^a-zA-Z0-9]/g, '');

--- a/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDeviceFactory.ts
@@ -87,7 +87,7 @@ export default class ButtplugIoDeviceFactory
         // Since we don't get a unique identifier for the Bluetooth device from Intiface,
         // we need to use the index assigned to the device by Intiface. It's the best we have.
         const nameString = buttplugDevice.name.replace(/[^a-zA-Z0-9]/g, '');
-        const deviceId = this.useDeviceNameAsId ? `buttplugio-${nameString}` : `buttplugio-${buttplugDevice.index}`;
+        const deviceId = useDeviceNameAsId ? `buttplugio-${nameString}` : `buttplugio-${buttplugDevice.index}`;
 
         let knownDevice = this.settings.getKnownDeviceById(deviceId)
 

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
@@ -81,13 +81,15 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
 
     private discoverButtplugIoDevices(): void {
         if (this.buttplugClient.connected) {
-            try {
-                this.logger.info('Start scanning for Buttplug.io devices');
-                this.buttplugClient.startScanning();
-                setTimeout(() => { this.buttplugClient.stopScanning(); }, 30000);
-            } catch (e: unknown) {
-                this.logger.error(`Could not start scanning for buttplug.io devices`, e);
-            }
+            this.buttplugClient.startScanning()
+                .then(() => this.logger.info('Start scanning for Buttplug.io devices'))
+                .catch((e: unknown) => this.logger.error(`Could not start scanning for buttplug.io devices`, e));
+
+            setTimeout(() => {
+                this.buttplugClient.stopScanning()
+                    .then(() => this.logger.info('Stop scanning for Buttplug.io devices'))
+                    .catch((e: unknown) => this.logger.error(`Could not stop scanning for buttplug.io devices`, e));
+            }, 30000);
          }
     }
 

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
@@ -80,10 +80,14 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
 
 
     private discoverButtplugIoDevices(): void {
-         if (this.buttplugClient.connected) {
-             this.logger.info('Start scanning for Buttplug.io devices');
-             this.buttplugClient.startScanning();
-             setTimeout(() => { this.buttplugClient.stopScanning(); }, 30000);
+        if (this.buttplugClient.connected) {
+            try {
+                this.logger.info('Start scanning for Buttplug.io devices');
+                this.buttplugClient.startScanning();
+                setTimeout(() => { this.buttplugClient.stopScanning(); }, 30000);
+            } catch (e: unknown) {
+                this.logger.error(`Could not start scanning for buttplug.io devices`, e);
+            }
          }
     }
 

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
@@ -79,8 +79,7 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
     }
 
 
-    private async discoverButtplugIoDevices(): Promise<void>
-    {
+    private discoverButtplugIoDevices(): void {
          if (this.buttplugClient.connected) {
              this.logger.info('Start scanning for Buttplug.io devices');
              this.buttplugClient.startScanning();

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
@@ -100,7 +100,7 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
         this.logger.info(`Buttplug.io device detected: ${buttplugDevice.name}`, buttplugDevice);
 
         try {
-            const device = this.buttplugIoDeviceFactory.create(buttplugDevice, ButtplugIoWebsocketDeviceProvider.name);
+            const device = this.buttplugIoDeviceFactory.create(buttplugDevice, ButtplugIoWebsocketDeviceProvider.name, this.useDeviceNameAsId);
             const deviceStatusUpdaterInterval = this.initDeviceStatusUpdater(device);
 
             this.connectedDevices.set(buttplugDevice.index, device);

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProvider.ts
@@ -20,21 +20,21 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
 
     private readonly websocketAddress: string;
     private readonly autoScan: boolean;
-    private readonly useNameAsSerial: boolean;
+    private readonly useDeviceNameAsId: boolean;
 
     public constructor(
         eventEmitter: EventEmitter,
         deviceFactory: ButtplugIoDeviceFactory,
         websocketAddress: string,
         autoScan: boolean,
-        useNameAsSerial: boolean,
+        useDeviceNameAsId: boolean,
         logger: Logger
     ) {
         super(eventEmitter, logger.child({ name: 'buttplugIoWebsocketDeviceProvider' }));
         this.buttplugIoDeviceFactory = deviceFactory;
         this.websocketAddress = websocketAddress;
         this.autoScan = autoScan;
-        this.useNameAsSerial = useNameAsSerial;
+        this.useDeviceNameAsId = useDeviceNameAsId;
     }
 
     public async init(): Promise<void>
@@ -58,7 +58,7 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
 
             setInterval(() => { this.connectToServer() }, 3000);
 
-            if (this.autoScan) {
+            if (true === this.autoScan) {
                 setInterval(() => { this.discoverButtplugIoDevices() }, 60000);
             }
 
@@ -80,17 +80,19 @@ export default class ButtplugIoWebsocketDeviceProvider extends DeviceProvider
 
 
     private discoverButtplugIoDevices(): void {
-        if (this.buttplugClient.connected) {
-            this.buttplugClient.startScanning()
-                .then(() => this.logger.info('Start scanning for Buttplug.io devices'))
-                .catch((e: unknown) => this.logger.error(`Could not start scanning for buttplug.io devices`, e));
+        if (false === this.buttplugClient.connected) {
+            return;
+        }
 
-            setTimeout(() => {
-                this.buttplugClient.stopScanning()
-                    .then(() => this.logger.info('Stop scanning for Buttplug.io devices'))
-                    .catch((e: unknown) => this.logger.error(`Could not stop scanning for buttplug.io devices`, e));
-            }, 30000);
-         }
+        this.buttplugClient.startScanning()
+            .then(() => this.logger.info('Start scanning for Buttplug.io devices'))
+            .catch((e: unknown) => this.logger.error(`Could not start scanning for buttplug.io devices`, e));
+
+        setTimeout(() => {
+            this.buttplugClient.stopScanning()
+                .then(() => this.logger.info('Stop scanning for Buttplug.io devices'))
+                .catch((e: unknown) => this.logger.error(`Could not stop scanning for buttplug.io devices`, e));
+        }, 30000);
     }
 
 

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProviderFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProviderFactory.ts
@@ -9,7 +9,7 @@ import ButtplugIoWebsocketDeviceProvider from "./buttplugIoWebsocketDeviceProvid
 type ButtplugIoWebsocketConfig = {
     address: string,
     autoScan: boolean,
-    useNameAsSerial: boolean
+    useDeviceNameAsId: boolean
 }
 
 export default class ButtplugIoWebsocketDeviceProviderFactory implements DeviceProviderFactory
@@ -39,7 +39,7 @@ export default class ButtplugIoWebsocketDeviceProviderFactory implements DeviceP
             this.deviceFactory,
             config.address,
             config.autoScan,
-            config.useNameAsSerial,
+            config.useDeviceNameAsId,
             this.logger
         );
     }

--- a/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProviderFactory.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoWebsocketDeviceProviderFactory.ts
@@ -8,6 +8,8 @@ import ButtplugIoWebsocketDeviceProvider from "./buttplugIoWebsocketDeviceProvid
 
 type ButtplugIoWebsocketConfig = {
     address: string,
+    autoScan: boolean,
+    useNameAsSerial: boolean
 }
 
 export default class ButtplugIoWebsocketDeviceProviderFactory implements DeviceProviderFactory
@@ -36,6 +38,8 @@ export default class ButtplugIoWebsocketDeviceProviderFactory implements DeviceP
             this.eventEmitter,
             this.deviceFactory,
             config.address,
+            config.autoScan,
+            config.useNameAsSerial,
             this.logger
         );
     }


### PR DESCRIPTION
Since scanning for new devices and device id persistence are specific features of intiface-central and are not implemented for exemple in intiface-engine, this Pull request add two new boolean settings in the deviceSource of type buttplugIoWebsocket :

**autoScan :** 
use the api to trigger device scanning on buttplug.io (30 sec of scan every minute)

**useNameAsSerial :** 
since intiface-engine doesn't have any id persistence the devices could be mixed up after restart. This setting allows to use name instead. 
Do not use this setting if you have more than one device with the same model.