### PR TITLE
Add parallel HTTPS server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ PORT=1337
 LOG_LEVEL=debug
 ALLOWED_ORIGINS=
 APP_VERSION=dev
+# SSL_KEY=/path/to/server.key
+# SSL_CERT=/path/to/server.crt
+# HTTPS_PORT=1338

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,6 @@ container
 
 const logger = container.get('logger.default');
 const io = container.get('server.websocket');
-
 const deviceManager = container.get('device.manager');
 const serialPortObserver = container.get('device.observer.serial');
 const settingsManager = container.get('settings.manager');
@@ -176,12 +175,12 @@ setIntervalAsync(async () => {
 
 httpServer.listen(APP_HTTP_PORT, () => {
     logger.info(`Node version: ${process.version}`);
-    logger.info(`SlvCtrl+ server listening on http://localhost:${APP_HTTP_PORT} (http)`);
+    logger.info(`SlvCtrl+ server listening on http://localhost:${APP_HTTP_PORT}`);
 });
 
 if (httpsServer !== undefined) {
     httpsServer.listen(APP_HTTPS_PORT, () => {
-        logger.info(`SlvCtrl+ server listening on https://localhost:${APP_HTTPS_PORT} (https)`);
+        logger.info(`SlvCtrl+ server listening on https://localhost:${APP_HTTPS_PORT} (ssl)`);
     });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import 'reflect-metadata';
-import cors from 'cors';
+import cors, { CorsOptions } from 'cors';
 import contentTypeMiddleware from './middleware/contentTypeMiddleware.js';
 import express from 'express';
 import { Pimple } from '@timesplinter/pimple';
@@ -11,15 +11,12 @@ import FactoryServiceProvider from './serviceProvider/factoryServiceProvider.js'
 import DeviceServiceProvider from './serviceProvider/deviceServiceProvider.js';
 import SettingsServiceProvider from './serviceProvider/settingsServiceProvider.js';
 import SchemaValidationServiceProvider from './serviceProvider/schemaValidationServiceProvider.js';
-import http from 'http'
-import https from 'https'
-import fs from 'fs'
 import SocketServiceProvider from './serviceProvider/socketServiceProvider.js';
 import { DeviceUpdateData } from './socket/types.js';
 import AutomationServiceProvider from './serviceProvider/automationServiceProvider.js';
 import Device from './device/device.js';
 import WebSocketEvent from './device/webSocketEvent.js';
-import ServerServiceProvider from './serviceProvider/serverServiceProvider.js';
+import ServerServiceProvider, { SslConfig } from './serviceProvider/serverServiceProvider.js';
 import AutomationEventType from './automation/automationEventType.js';
 import LoggerServiceProvider from './serviceProvider/loggerServiceProvider.js';
 import DeviceDiscriminator from './serialization/discriminator/deviceDiscriminator.js';
@@ -43,17 +40,27 @@ const ALLOWED_ORIGINS = undefined !== process.env.ALLOWED_ORIGINS && null !== pr
 const SSL_KEY_FILE = process.env.SSL_KEY;
 const SSL_CERT_FILE = process.env.SSL_CERT;
 
-const container = new Pimple<ServiceMap>();
-const app = express();
-const httpServer = http.createServer(app);
-const httpsServer = SSL_KEY_FILE !== undefined && SSL_CERT_FILE !== undefined
-    ? https.createServer({ key: fs.readFileSync(SSL_KEY_FILE), cert: fs.readFileSync(SSL_CERT_FILE) }, app)
+const sslConfig: SslConfig | undefined = SSL_KEY_FILE !== undefined && SSL_CERT_FILE !== undefined
+    ? { keyFile: SSL_KEY_FILE, certFile: SSL_CERT_FILE }
     : undefined;
+
+const corsOptions: CorsOptions = {
+    origin: (origin, callback) => {
+        if (undefined === origin || ALLOWED_ORIGINS.length === 0) {
+            return callback(null, true);
+        }
+
+        return callback(null, ALLOWED_ORIGINS.includes(origin));
+    },
+};
+
+const app = express();
+const container = new Pimple<ServiceMap>();
 
 container
     .register(new LoggerServiceProvider())
     .register(new HealthServiceProvider())
-    .register(new ServerServiceProvider(httpServer, httpsServer))
+    .register(new ServerServiceProvider(app, corsOptions, sslConfig))
     .register(new SettingsServiceProvider())
     .register(new DeviceServiceProvider())
     .register(new ControllerServiceProvider())
@@ -86,15 +93,7 @@ app
 
         next();
     })
-    .use(cors({
-        origin: (origin, callback) => {
-            if (undefined === origin || ALLOWED_ORIGINS.length === 0) {
-                return callback(null, true);
-            }
-
-            return callback(null, ALLOWED_ORIGINS.includes(origin));
-        },
-    }))
+    .use(cors(corsOptions))
     .use(contentTypeMiddleware)
     .use(express.json())
     .use(express.text())
@@ -172,6 +171,9 @@ setIntervalAsync(async () => {
     timeoutMs: 2_000,
     onError: (err) => logError(logger, 'Health metrics broadcast failed', err),
 });
+
+const httpServer = container.get('server.http');
+const httpsServer = container.get('server.https');
 
 httpServer.listen(APP_HTTP_PORT, () => {
     logger.info(`Node version: ${process.version}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import DeviceServiceProvider from './serviceProvider/deviceServiceProvider.js';
 import SettingsServiceProvider from './serviceProvider/settingsServiceProvider.js';
 import SchemaValidationServiceProvider from './serviceProvider/schemaValidationServiceProvider.js';
 import http from 'http'
+import https from 'https'
+import fs from 'fs'
 import SocketServiceProvider from './serviceProvider/socketServiceProvider.js';
 import { DeviceUpdateData } from './socket/types.js';
 import AutomationServiceProvider from './serviceProvider/automationServiceProvider.js';
@@ -30,21 +32,28 @@ import { logError } from './util/error.js';
 import { setIntervalAsync } from './util/async.js';
 import HealthServiceProvider from './serviceProvider/healthServiceProvider.js';
 
-const APP_PORT = process.env.PORT ?? '1337';
+const APP_HTTP_PORT = process.env.PORT ?? '1337';
+const APP_HTTPS_PORT = process.env.HTTPS_PORT ?? '1338';
 const ALLOWED_ORIGINS = undefined !== process.env.ALLOWED_ORIGINS && null !== process.env.ALLOWED_ORIGINS.length
     ? process.env.ALLOWED_ORIGINS.split(',')
         .map(origin => origin.trim())
         .filter(origin => origin.length > 0)
     : [];
 
+const SSL_KEY_FILE = process.env.SSL_KEY;
+const SSL_CERT_FILE = process.env.SSL_CERT;
+
 const container = new Pimple<ServiceMap>();
 const app = express();
 const httpServer = http.createServer(app);
+const httpsServer = SSL_KEY_FILE !== undefined && SSL_CERT_FILE !== undefined
+    ? https.createServer({ key: fs.readFileSync(SSL_KEY_FILE), cert: fs.readFileSync(SSL_CERT_FILE) }, app)
+    : undefined;
 
 container
     .register(new LoggerServiceProvider())
     .register(new HealthServiceProvider())
-    .register(new ServerServiceProvider(httpServer))
+    .register(new ServerServiceProvider(httpServer, httpsServer))
     .register(new SettingsServiceProvider())
     .register(new DeviceServiceProvider())
     .register(new ControllerServiceProvider())
@@ -58,6 +67,7 @@ container
 
 const logger = container.get('logger.default');
 const io = container.get('server.websocket');
+
 const deviceManager = container.get('device.manager');
 const serialPortObserver = container.get('device.observer.serial');
 const settingsManager = container.get('settings.manager');
@@ -164,10 +174,16 @@ setIntervalAsync(async () => {
     onError: (err) => logError(logger, 'Health metrics broadcast failed', err),
 });
 
-httpServer.listen(APP_PORT, () => {
+httpServer.listen(APP_HTTP_PORT, () => {
     logger.info(`Node version: ${process.version}`);
-    logger.info(`SlvCtrl+ server listening on port ${APP_PORT}!`);
+    logger.info(`SlvCtrl+ server listening on http://localhost:${APP_HTTP_PORT} (http)`);
 });
+
+if (httpsServer !== undefined) {
+    httpsServer.listen(APP_HTTPS_PORT, () => {
+        logger.info(`SlvCtrl+ server listening on https://localhost:${APP_HTTPS_PORT} (https)`);
+    });
+}
 
 process.on('uncaughtException', (error: Error) => {
     logger.error('Asynchronous error caught', error);

--- a/src/serviceMap.ts
+++ b/src/serviceMap.ts
@@ -1,4 +1,6 @@
 import { Ajv } from 'ajv';
+import type http from 'http';
+import type https from 'https';
 import { Server } from 'socket.io';
 import ClassToPlainSerializer from './serialization/classToPlainSerializer.js';
 import PlainToClassSerializer from './serialization/plainToClassSerializer.js';
@@ -56,6 +58,8 @@ type ServiceMap = {
     'logger.default': Logger,
 
     /* serverServiceProvider */
+    'server.http': http.Server,
+    'server.https': https.Server | undefined,
     'server.websocket': Server,
 
     /* deviceServiceProvider */

--- a/src/serviceProvider/serverServiceProvider.ts
+++ b/src/serviceProvider/serverServiceProvider.ts
@@ -6,19 +6,29 @@ import ServiceMap from '../serviceMap.js';
 export default class ServerServiceProvider implements ServiceProvider<ServiceMap>
 {
     private readonly httpServer: http.Server;
+    private readonly httpsServer?: http.Server;
 
-    public constructor(server: http.Server) {
+    public constructor(server: http.Server, httpsServer?: http.Server) {
         this.httpServer = server;
+        this.httpsServer = httpsServer;
     }
 
     public register(container: Pimple<ServiceMap>): void {
         container.set('server.websocket', () => {
-            return new Server(this.httpServer, {
+            const socketIoServer = new Server(undefined, {
                 cors: {
                     origin: '*',
                     methods: ['GET', 'POST', 'PATCH']
                 }
             });
+
+            socketIoServer.attach(this.httpServer);
+
+            if (this.httpsServer) {
+                socketIoServer.attach(this.httpsServer);
+            }
+
+            return socketIoServer;
         });
     }
 }

--- a/src/serviceProvider/serverServiceProvider.ts
+++ b/src/serviceProvider/serverServiceProvider.ts
@@ -1,34 +1,61 @@
+import BaseError from 'modern-errors';
 import { Pimple, ServiceProvider } from '@timesplinter/pimple';
 import http from 'http'
+import https from 'https'
+import fs from 'fs'
 import { Server } from 'socket.io';
 import ServiceMap from '../serviceMap.js';
+import { CorsOptions } from 'cors';
+import express from 'express';
+
+export type SslConfig = { keyFile: string, certFile: string };
 
 export default class ServerServiceProvider implements ServiceProvider<ServiceMap>
 {
-    private readonly httpServer: http.Server;
-    private readonly httpsServer?: http.Server;
+    private readonly app: express.Application;
+    private readonly corsOptions: CorsOptions;
+    private readonly sslConfig?: SslConfig;
 
-    public constructor(server: http.Server, httpsServer?: http.Server) {
-        this.httpServer = server;
-        this.httpsServer = httpsServer;
+    public constructor(app: express.Application, corsOptions: CorsOptions, sslConfig?: SslConfig) {
+        this.app = app;
+        this.corsOptions = corsOptions;
+        this.sslConfig = sslConfig;
     }
 
     public register(container: Pimple<ServiceMap>): void {
-        container.set('server.websocket', () => {
-            const socketIoServer = new Server(undefined, {
-                cors: {
-                    origin: '*',
-                    methods: ['GET', 'POST', 'PATCH']
-                }
-            });
+        container.set('server.websocket', () => new Server(undefined, {
+            cors: this.corsOptions
+        }));
 
-            socketIoServer.attach(this.httpServer);
+        container.set('server.http', () => {
+            const server = http.createServer(this.app);
 
-            if (this.httpsServer) {
-                socketIoServer.attach(this.httpsServer);
+            container.get('server.websocket').attach(server);
+
+            return server;
+        });
+
+        container.set('server.https', () => {
+            if (this.sslConfig === undefined) {
+                return undefined;
             }
 
-            return socketIoServer;
+            const logger = container.get('logger.default');
+
+            try {
+                const key = fs.readFileSync(this.sslConfig.keyFile);
+                const cert = fs.readFileSync(this.sslConfig.certFile);
+                const server = https.createServer({ key, cert }, this.app);
+
+                container.get('server.websocket').attach(server);
+
+                return server;
+            } catch (err) {
+                const baseError = BaseError.normalize(err);
+                logger.error(`Failed to load SSL certificates: ${baseError.message}`);
+                logger.warn('HTTPS server will not be started');
+                return undefined;
+            }
         });
     }
 }

--- a/src/util/async.ts
+++ b/src/util/async.ts
@@ -1,5 +1,12 @@
 export const sleep = (ms: number): Promise<void> => new Promise<void>(r => setTimeout(r, ms));
 
+export class IntervalTimeoutError extends Error {
+  public constructor(timeoutMs: number) {
+    super(`Interval function timed out (>${timeoutMs}ms)`);
+    this.name = 'IntervalTimeoutError';
+  }
+}
+
 export const setImmediateInterval = <TArgs extends any[]>(
   callback: (...args: TArgs) => void,
   delay?: number,
@@ -41,10 +48,11 @@ export const setIntervalAsync = <TArgs extends any[]>(
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     if (undefined !== options.timeoutMs) {
+      const timeoutMs = options.timeoutMs;
       promises.push(new Promise<void>((_, reject) =>
         timeoutHandle = setTimeout(() => {
-          reject(new Error(`Interval function timed out (>${options.timeoutMs}ms)`));
-        }, options.timeoutMs))
+          reject(new IntervalTimeoutError(timeoutMs));
+        }, timeoutMs))
       );
     }
 

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -1,7 +1,13 @@
 import BaseError from 'modern-errors';
 import Logger from '../logging/Logger.js';
+import { IntervalTimeoutError } from './async.js';
 
 export const logError = (logger: Logger, message: string, error: unknown): void => {
+    if (error instanceof IntervalTimeoutError) {
+        logger.warn(`${message}: ${error.message}`);
+        return;
+    }
+
     const baseError = error instanceof Error ? error : BaseError.normalize(error);
     logger.error(`${message}: ${baseError.message}`, baseError);
 };


### PR DESCRIPTION
When SSL_KEY and SSL_CERT env vars point to valid certificate files, an HTTPS server starts alongside the always-on HTTP server on HTTPS_PORT (default 1338). Socket.IO attaches to both servers via ServerServiceProvider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HTTPS support with configurable SSL certificates and a dedicated HTTPS port.
  * Specialized error handling for async interval timeout scenarios.

* **Refactor**
  * Server startup split to support separate HTTP/HTTPS listeners; CORS origin handling centralized into shared configuration.

* **Chores**
  * Updated configuration documentation with HTTPS setup placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->