### PR TITLE
Switch to new actions and use npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Setup Virtual ALSA Device
         uses: ./.github/actions/setup-virtual-alsa
       - name: Set node version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
       - name: Install modules
-        run: npm install
+        run: npm ci
       - name: Tag
         id: set_tag
         uses: K-Phoen/semver-release-action@v1.3.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use a newer Node setup action.
  * Switched dependency installation to a cleaner, lockfile-based install during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->