### PR TITLE
Refactor DeviceAttribute generics to eliminate "as T" assertions

### DIFF
--- a/src/device/attribute/boolDeviceAttribute.ts
+++ b/src/device/attribute/boolDeviceAttribute.ts
@@ -1,11 +1,11 @@
-import type { DeviceAttributeModifier, NotJustUndefined, NotUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 
-type BoolDeviceAttributeValue = NotJustUndefined<boolean | undefined>;
+type BoolDeviceAttributeValue = boolean | undefined;
 
 export type InitializedBoolDeviceAttribute = BoolDeviceAttribute<boolean>;
 
-export default class BoolDeviceAttribute<T extends BoolDeviceAttributeValue = BoolDeviceAttributeValue> extends DeviceAttribute<T>
+export default class BoolDeviceAttribute<T extends BoolDeviceAttributeValue = BoolDeviceAttributeValue> extends DeviceAttribute<boolean, T>
 {
     public static createInitialized(
         name: string,
@@ -24,13 +24,11 @@ export default class BoolDeviceAttribute<T extends BoolDeviceAttributeValue = Bo
         return new BoolDeviceAttribute(name, label, modifier, undefined);
     }
 
-    public override fromString(value: string): T {
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return (value === '1') as T;
+    public override fromString(value: string): boolean {
+        return value === '1';
     }
 
-    public override isValidValue(value: unknown): value is NotUndefined<T> {
+    public override isValidValue(value: unknown): value is boolean {
         return typeof value === 'boolean';
     }
 

--- a/src/device/attribute/boolDeviceAttribute.ts
+++ b/src/device/attribute/boolDeviceAttribute.ts
@@ -3,7 +3,7 @@ import DeviceAttribute from './deviceAttribute.js';
 
 export type InitializedBoolDeviceAttribute = BoolDeviceAttribute<true>;
 
-export default class BoolDeviceAttribute<IsSet extends boolean = false> extends DeviceAttribute<boolean, IsSet>
+export default class BoolDeviceAttribute<IsInitialized extends boolean = false> extends DeviceAttribute<boolean, IsInitialized>
 {
     public static createInitialized(
         name: string,

--- a/src/device/attribute/boolDeviceAttribute.ts
+++ b/src/device/attribute/boolDeviceAttribute.ts
@@ -1,11 +1,9 @@
 import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 
-type BoolDeviceAttributeValue = boolean | undefined;
+export type InitializedBoolDeviceAttribute = BoolDeviceAttribute<true>;
 
-export type InitializedBoolDeviceAttribute = BoolDeviceAttribute<boolean>;
-
-export default class BoolDeviceAttribute<T extends BoolDeviceAttributeValue = BoolDeviceAttributeValue> extends DeviceAttribute<boolean, T>
+export default class BoolDeviceAttribute<IsSet extends boolean = false> extends DeviceAttribute<boolean, IsSet>
 {
     public static createInitialized(
         name: string,
@@ -13,7 +11,7 @@ export default class BoolDeviceAttribute<T extends BoolDeviceAttributeValue = Bo
         modifier: DeviceAttributeModifier,
         initialValue: boolean,
     ): InitializedBoolDeviceAttribute {
-        return new BoolDeviceAttribute<boolean>(name, label, modifier, initialValue);
+        return new BoolDeviceAttribute<true>(name, label, modifier, initialValue);
     }
 
     public static create(

--- a/src/device/attribute/deviceAttribute.ts
+++ b/src/device/attribute/deviceAttribute.ts
@@ -1,12 +1,9 @@
 import { Exclude, Expose } from 'class-transformer';
 import type { Float, Int } from '../../util/numbers.js';
 
-export type BaseAttributeValue = string | Int | Float | boolean | null;
-export type AttributeValue = BaseAttributeValue | undefined;
+export type AllowedAttributeType = string | Int | Float | boolean | null;
 
-// The storage/getter/setter type for an attribute: the concrete value V once it has been set
-// (IsSet = true), or V | undefined beforehand (IsSet = false, the default).
-export type AttributeStorage<V extends BaseAttributeValue, IsSet extends boolean> = IsSet extends true ? V : V | undefined;
+export type AttributeValue<V extends AllowedAttributeType = AllowedAttributeType, IsInitialized extends boolean = false> = IsInitialized extends true ? V : V | undefined;
 
 export enum DeviceAttributeModifier
 {
@@ -15,15 +12,15 @@ export enum DeviceAttributeModifier
     writeOnly = 'wo',
 }
 
-export const isValidAttributeValue = <V extends BaseAttributeValue, IsSet extends boolean = boolean>(
-    attribute: DeviceAttribute<V, IsSet> | undefined,
+export const isValidAttributeValue = <V extends AllowedAttributeType, IsInitialized extends boolean = boolean>(
+    attribute: DeviceAttribute<V, IsInitialized> | undefined,
     value: unknown,
 ): value is V => attribute?.isValidValue(value) ?? false;
 
 @Exclude()
 export default abstract class DeviceAttribute<
-    V extends BaseAttributeValue = BaseAttributeValue,
-    IsSet extends boolean = false,
+    V extends AllowedAttributeType = AllowedAttributeType,
+    IsInitialized extends boolean = false,
 >
 {
     @Expose({ name: 'name' })
@@ -36,9 +33,9 @@ export default abstract class DeviceAttribute<
     private readonly _modifier: DeviceAttributeModifier;
 
     @Expose({ name: 'value' })
-    private _value: AttributeStorage<V, IsSet>;
+    private _value: AttributeValue<V, IsInitialized>;
 
-    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, initialValue: AttributeStorage<V, IsSet>) {
+    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, initialValue: AttributeValue<V, IsInitialized>) {
         this._name = name;
         this._label = label;
         this._modifier = modifier;
@@ -64,11 +61,11 @@ export default abstract class DeviceAttribute<
     /**
      * @returns the current value or undefined if it has never been set or read from the device
      */
-    public get value(): AttributeStorage<V, IsSet> {
+    public get value(): AttributeValue<V, IsInitialized> {
         return this._value;
     }
 
-    public set value(value: AttributeStorage<V, IsSet>) {
+    public set value(value: AttributeValue<V, IsInitialized>) {
         this._value = value;
     }
 

--- a/src/device/attribute/deviceAttribute.ts
+++ b/src/device/attribute/deviceAttribute.ts
@@ -1,9 +1,8 @@
 import { Exclude, Expose } from 'class-transformer';
 import type { Float, Int } from '../../util/numbers.js';
 
-export type NotJustUndefined<V> = [V] extends [undefined] ? never : V;
-export type NotUndefined<V> = V extends undefined ? never : V;
-export type AttributeValue = NotJustUndefined<string | Int | Float | boolean | null | undefined>;
+export type BaseAttributeValue = string | Int | Float | boolean | null;
+export type AttributeValue = BaseAttributeValue | undefined;
 
 export enum DeviceAttributeModifier
 {
@@ -12,13 +11,16 @@ export enum DeviceAttributeModifier
     writeOnly = 'wo',
 }
 
-export const isValidAttributeValue = <T extends AttributeValue>(
-    attribute: DeviceAttribute<T> | undefined,
+export const isValidAttributeValue = <V extends BaseAttributeValue, T extends V | undefined = V | undefined>(
+    attribute: DeviceAttribute<V, T> | undefined,
     value: unknown,
-): value is NotUndefined<T> => attribute?.isValidValue(value) ?? false;
+): value is V => attribute?.isValidValue(value) ?? false;
 
 @Exclude()
-export default abstract class DeviceAttribute<T extends AttributeValue = AttributeValue>
+export default abstract class DeviceAttribute<
+    V extends BaseAttributeValue = BaseAttributeValue,
+    T extends V | undefined = V | undefined,
+>
 {
     @Expose({ name: 'name' })
     private readonly _name: string;
@@ -76,7 +78,7 @@ export default abstract class DeviceAttribute<T extends AttributeValue = Attribu
         throw new Error(`Not implemented`);
     }
 
-    public abstract fromString(value: string): T;
+    public abstract fromString(value: string): V;
 
-    public abstract isValidValue(value: unknown): value is NotUndefined<T>;
+    public abstract isValidValue(value: unknown): value is V;
 }

--- a/src/device/attribute/deviceAttribute.ts
+++ b/src/device/attribute/deviceAttribute.ts
@@ -4,6 +4,10 @@ import type { Float, Int } from '../../util/numbers.js';
 export type BaseAttributeValue = string | Int | Float | boolean | null;
 export type AttributeValue = BaseAttributeValue | undefined;
 
+// The storage/getter/setter type for an attribute: the concrete value V once it has been set
+// (IsSet = true), or V | undefined beforehand (IsSet = false, the default).
+export type AttributeStorage<V extends BaseAttributeValue, IsSet extends boolean> = IsSet extends true ? V : V | undefined;
+
 export enum DeviceAttributeModifier
 {
     readOnly = 'ro',
@@ -11,15 +15,15 @@ export enum DeviceAttributeModifier
     writeOnly = 'wo',
 }
 
-export const isValidAttributeValue = <V extends BaseAttributeValue, T extends V | undefined = V | undefined>(
-    attribute: DeviceAttribute<V, T> | undefined,
+export const isValidAttributeValue = <V extends BaseAttributeValue, IsSet extends boolean = boolean>(
+    attribute: DeviceAttribute<V, IsSet> | undefined,
     value: unknown,
 ): value is V => attribute?.isValidValue(value) ?? false;
 
 @Exclude()
 export default abstract class DeviceAttribute<
     V extends BaseAttributeValue = BaseAttributeValue,
-    T extends V | undefined = V | undefined,
+    IsSet extends boolean = false,
 >
 {
     @Expose({ name: 'name' })
@@ -32,9 +36,9 @@ export default abstract class DeviceAttribute<
     private readonly _modifier: DeviceAttributeModifier;
 
     @Expose({ name: 'value' })
-    private _value: T;
+    private _value: AttributeStorage<V, IsSet>;
 
-    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, initialValue: T) {
+    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, initialValue: AttributeStorage<V, IsSet>) {
         this._name = name;
         this._label = label;
         this._modifier = modifier;
@@ -60,15 +64,15 @@ export default abstract class DeviceAttribute<
     /**
      * @returns the current value or undefined if it has never been set or read from the device
      */
-    public get value(): T {
+    public get value(): AttributeStorage<V, IsSet> {
         return this._value;
     }
 
-    public set value(value: T) {
+    public set value(value: AttributeStorage<V, IsSet>) {
         this._value = value;
     }
 
-    public hasValue(): this is { value: T } {
+    public hasValue(): this is { value: V } {
         return this._value !== undefined;
     }
 

--- a/src/device/attribute/floatDeviceAttribute.ts
+++ b/src/device/attribute/floatDeviceAttribute.ts
@@ -1,12 +1,12 @@
-import type { DeviceAttributeModifier, NotJustUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import { Float } from '../../util/numbers.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
-type FloatDeviceAttributeValue = NotJustUndefined<Float | undefined>;
+type FloatDeviceAttributeValue = Float | undefined;
 
 export type InitializedFloatGenericDeviceAttribute = FloatDeviceAttribute<Float>;
 
-export default class FloatDeviceAttribute<T extends FloatDeviceAttributeValue = FloatDeviceAttributeValue> extends NumberDeviceAttribute<T>
+export default class FloatDeviceAttribute<T extends FloatDeviceAttributeValue = FloatDeviceAttributeValue> extends NumberDeviceAttribute<Float, T>
 {
     public constructor(
         name: string,
@@ -37,16 +37,14 @@ export default class FloatDeviceAttribute<T extends FloatDeviceAttributeValue = 
         return new FloatDeviceAttribute(name, label, modifier, uom, undefined);
     }
 
-    public fromString(value: string): T {
+    public fromString(value: string): Float {
         const num = parseFloat(value);
 
         if (isNaN(num)) {
             throw new Error(`Could not convert '${value}' to a valid value for ${this.constructor.name}`);
         }
 
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return Float.from(num) as T;
+        return Float.from(num);
     }
 
     public override getType(): string {

--- a/src/device/attribute/floatDeviceAttribute.ts
+++ b/src/device/attribute/floatDeviceAttribute.ts
@@ -1,19 +1,17 @@
-import type { DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
 import { Float } from '../../util/numbers.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
-type FloatDeviceAttributeValue = Float | undefined;
+export type InitializedFloatGenericDeviceAttribute = FloatDeviceAttribute<true>;
 
-export type InitializedFloatGenericDeviceAttribute = FloatDeviceAttribute<Float>;
-
-export default class FloatDeviceAttribute<T extends FloatDeviceAttributeValue = FloatDeviceAttributeValue> extends NumberDeviceAttribute<Float, T>
+export default class FloatDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Float, IsSet>
 {
     public constructor(
         name: string,
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         uom: string | undefined,
-        initialValue: T,
+        initialValue: AttributeStorage<Float, IsSet>,
     ) {
         super(name, label, modifier, uom, initialValue);
     }
@@ -25,7 +23,7 @@ export default class FloatDeviceAttribute<T extends FloatDeviceAttributeValue = 
         uom: string | undefined,
         initialValue: Float,
     ): InitializedFloatGenericDeviceAttribute {
-        return new FloatDeviceAttribute<Float>(name, label, modifier, uom, initialValue);
+        return new FloatDeviceAttribute<true>(name, label, modifier, uom, initialValue);
     }
 
     public static create(

--- a/src/device/attribute/floatDeviceAttribute.ts
+++ b/src/device/attribute/floatDeviceAttribute.ts
@@ -1,17 +1,17 @@
-import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeValue, DeviceAttributeModifier } from './deviceAttribute.js';
 import { Float } from '../../util/numbers.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
 export type InitializedFloatGenericDeviceAttribute = FloatDeviceAttribute<true>;
 
-export default class FloatDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Float, IsSet>
+export default class FloatDeviceAttribute<IsInitialized extends boolean = false> extends NumberDeviceAttribute<Float, IsInitialized>
 {
     public constructor(
         name: string,
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         uom: string | undefined,
-        initialValue: AttributeStorage<Float, IsSet>,
+        initialValue: AttributeValue<Float, IsInitialized>,
     ) {
         super(name, label, modifier, uom, initialValue);
     }

--- a/src/device/attribute/floatDeviceAttribute.ts
+++ b/src/device/attribute/floatDeviceAttribute.ts
@@ -45,6 +45,10 @@ export default class FloatDeviceAttribute<IsInitialized extends boolean = false>
         return Float.from(num);
     }
 
+    public override isValidValue(value: unknown): value is Float {
+        return typeof value === 'number' && Number.isFinite(value);
+    }
+
     public override getType(): string {
         return 'float';
     }

--- a/src/device/attribute/intDeviceAttribute.ts
+++ b/src/device/attribute/intDeviceAttribute.ts
@@ -1,11 +1,11 @@
-import type { DeviceAttributeModifier, NotJustUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import { Int } from '../../util/numbers.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
-export type IntAttributeValue = NotJustUndefined<Int | undefined>;
+export type IntAttributeValue = Int | undefined;
 export type InitializedIntGenericDeviceAttribute = IntDeviceAttribute<Int>;
 
-export default class IntDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<T>
+export default class IntDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<Int, T>
 {
     public static createInitialized(
         name: string,
@@ -26,16 +26,14 @@ export default class IntDeviceAttribute<T extends IntAttributeValue = IntAttribu
         return new IntDeviceAttribute(name, label, modifier, uom, undefined);
     }
 
-    public fromString(value: string): T {
+    public fromString(value: string): Int {
         const num = parseInt(value, 10);
 
         if (isNaN(num)) {
             throw new Error(`Could not convert '${value}' to a valid value for ${this.constructor.name}`);
         }
 
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return Int.from(num) as T;
+        return Int.from(num);
     }
 
     public override getType(): string {

--- a/src/device/attribute/intDeviceAttribute.ts
+++ b/src/device/attribute/intDeviceAttribute.ts
@@ -4,7 +4,7 @@ import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
 export type InitializedIntGenericDeviceAttribute = IntDeviceAttribute<true>;
 
-export default class IntDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Int, IsSet>
+export default class IntDeviceAttribute<IsInitialized extends boolean = false> extends NumberDeviceAttribute<Int, IsInitialized>
 {
     public static createInitialized(
         name: string,

--- a/src/device/attribute/intDeviceAttribute.ts
+++ b/src/device/attribute/intDeviceAttribute.ts
@@ -35,6 +35,10 @@ export default class IntDeviceAttribute<IsInitialized extends boolean = false> e
         return Int.from(num);
     }
 
+    public override isValidValue(value: unknown): value is Int {
+        return typeof value === 'number' && Number.isInteger(value);
+    }
+
     public override getType(): string {
         return 'int';
     }

--- a/src/device/attribute/intDeviceAttribute.ts
+++ b/src/device/attribute/intDeviceAttribute.ts
@@ -2,10 +2,9 @@ import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import { Int } from '../../util/numbers.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
-export type IntAttributeValue = Int | undefined;
-export type InitializedIntGenericDeviceAttribute = IntDeviceAttribute<Int>;
+export type InitializedIntGenericDeviceAttribute = IntDeviceAttribute<true>;
 
-export default class IntDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<Int, T>
+export default class IntDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Int, IsSet>
 {
     public static createInitialized(
         name: string,
@@ -14,7 +13,7 @@ export default class IntDeviceAttribute<T extends IntAttributeValue = IntAttribu
         uom: string | undefined,
         initialValue: Int,
     ): InitializedIntGenericDeviceAttribute {
-        return new IntDeviceAttribute<Int>(name, label, modifier, uom, initialValue);
+        return new IntDeviceAttribute<true>(name, label, modifier, uom, initialValue);
     }
 
     public static create(

--- a/src/device/attribute/intRangeDeviceAttribute.ts
+++ b/src/device/attribute/intRangeDeviceAttribute.ts
@@ -87,6 +87,10 @@ export default class IntRangeDeviceAttribute<IsInitialized extends boolean = fal
         return Int.from(res);
     }
 
+    public override isValidValue(value: unknown): value is Int {
+        return typeof value === 'number' && Number.isInteger(value);
+    }
+
     public override getType(): string {
         return 'range';
     }

--- a/src/device/attribute/intRangeDeviceAttribute.ts
+++ b/src/device/attribute/intRangeDeviceAttribute.ts
@@ -6,7 +6,7 @@ import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
 export type InitializedIntRangeDeviceAttribute = IntRangeDeviceAttribute<Int>;
 
-export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<T>
+export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<Int, T>
 {
     @Expose({ name: 'min' })
     private _min: Int;
@@ -69,16 +69,14 @@ export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAt
         return this._incrementStep;
     }
 
-    public fromString(value: string): T {
+    public fromString(value: string): Int {
         const res = parseInt(value, 10);
 
         if (isNaN(res)) {
             throw new Error(`Could not convert '${value}' to a valid value for ${this.constructor.name}`);
         }
 
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return res as T;
+        return Int.from(res);
     }
 
     public override getType(): string {

--- a/src/device/attribute/intRangeDeviceAttribute.ts
+++ b/src/device/attribute/intRangeDeviceAttribute.ts
@@ -1,11 +1,11 @@
 import { Expose } from 'class-transformer';
 import { Int } from '../../util/numbers.js';
-import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeValue, DeviceAttributeModifier } from './deviceAttribute.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
 export type InitializedIntRangeDeviceAttribute = IntRangeDeviceAttribute<true>;
 
-export default class IntRangeDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Int, IsSet>
+export default class IntRangeDeviceAttribute<IsInitialized extends boolean = false> extends NumberDeviceAttribute<Int, IsInitialized>
 {
     @Expose({ name: 'min' })
     private _min: Int;
@@ -16,7 +16,16 @@ export default class IntRangeDeviceAttribute<IsSet extends boolean = false> exte
     @Expose({ name: 'incrementStep' })
     private readonly _incrementStep: Int = Int.from(1);
 
-    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, uom: string | undefined, min: Int, max: Int, incrementStep: Int, initialValue: AttributeStorage<Int, IsSet>) {
+    public constructor(
+        name: string,
+        label: string | undefined,
+        modifier: DeviceAttributeModifier,
+        uom: string | undefined,
+        min: Int,
+        max: Int,
+        incrementStep: Int,
+        initialValue: AttributeValue<Int, IsInitialized>,
+    ) {
         super(name, label, modifier, uom, initialValue);
         this._min = min;
         this._max = max;

--- a/src/device/attribute/intRangeDeviceAttribute.ts
+++ b/src/device/attribute/intRangeDeviceAttribute.ts
@@ -1,12 +1,11 @@
 import { Expose } from 'class-transformer';
-import type { IntAttributeValue } from './intDeviceAttribute.js';
 import { Int } from '../../util/numbers.js';
-import type { DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
 import NumberDeviceAttribute from './numberDeviceAttribute.js';
 
-export type InitializedIntRangeDeviceAttribute = IntRangeDeviceAttribute<Int>;
+export type InitializedIntRangeDeviceAttribute = IntRangeDeviceAttribute<true>;
 
-export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAttributeValue> extends NumberDeviceAttribute<Int, T>
+export default class IntRangeDeviceAttribute<IsSet extends boolean = false> extends NumberDeviceAttribute<Int, IsSet>
 {
     @Expose({ name: 'min' })
     private _min: Int;
@@ -17,7 +16,7 @@ export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAt
     @Expose({ name: 'incrementStep' })
     private readonly _incrementStep: Int = Int.from(1);
 
-    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, uom: string | undefined, min: Int, max: Int, incrementStep: Int, initialValue: T) {
+    public constructor(name: string, label: string | undefined, modifier: DeviceAttributeModifier, uom: string | undefined, min: Int, max: Int, incrementStep: Int, initialValue: AttributeStorage<Int, IsSet>) {
         super(name, label, modifier, uom, initialValue);
         this._min = min;
         this._max = max;
@@ -34,7 +33,7 @@ export default class IntRangeDeviceAttribute<T extends IntAttributeValue = IntAt
         incrementStep: Int,
         initialValue: Int,
     ): InitializedIntRangeDeviceAttribute {
-        return new IntRangeDeviceAttribute<Int>(name, label, modifier, uom, min, max, incrementStep, initialValue);
+        return new IntRangeDeviceAttribute<true>(name, label, modifier, uom, min, max, incrementStep, initialValue);
     }
 
     public static create(

--- a/src/device/attribute/listDeviceAttribute.ts
+++ b/src/device/attribute/listDeviceAttribute.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import type { DeviceAttributeModifier, NotUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import type { Int } from '../../util/numbers.js';
 
@@ -16,8 +16,8 @@ export type ListDeviceAttributeOptions<IKey, IValue> = ListDeviceAttributeOption
 export default class ListDeviceAttribute<
     IKey extends ListDeviceAttributeItem,
     IValue extends ListDeviceAttributeItem,
-    V extends IKey | undefined = IKey | undefined,
-> extends DeviceAttribute<V>
+    T extends IKey | undefined = IKey | undefined,
+> extends DeviceAttribute<IKey, T>
 {
     @Expose({ name: 'values' })
     private _values: ListDeviceAttributeOptions<IKey, IValue>;
@@ -27,7 +27,7 @@ export default class ListDeviceAttribute<
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         values: ListDeviceAttributeOptions<IKey, IValue>,
-        initialValue: V,
+        initialValue: T,
     ) {
         super(name, label, modifier, initialValue);
 
@@ -57,18 +57,18 @@ export default class ListDeviceAttribute<
         );
     }
 
-    public fromString(value: string): V {
+    public fromString(value: string): IKey {
         if (this._values.length === 0 || typeof this._values[0]?.key === 'string') {
-            // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
+            // The value kind (IKey) is chosen by the caller per instance, so TypeScript can't
+            // prove `value`/the parsed number is an IKey here - see issue #107 for details.
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-            return value as V;
+            return value as IKey;
         }
 
         const parsedInt = parseInt(value, 10);
 
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return (isNaN(parsedInt) ? value : parsedInt) as V;
+        return (isNaN(parsedInt) ? value : parsedInt) as IKey;
     }
 
     public get values(): ListDeviceAttributeOptions<IKey, IValue> {
@@ -79,7 +79,7 @@ export default class ListDeviceAttribute<
         this._values = value;
     }
 
-    public isValidValue(value: unknown): value is NotUndefined<V> {
+    public isValidValue(value: unknown): value is IKey {
         if (typeof value === 'string' || typeof value === 'number') {
             return -1 !== this._values.findIndex(entry => entry.key === value);
         }

--- a/src/device/attribute/listDeviceAttribute.ts
+++ b/src/device/attribute/listDeviceAttribute.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeValue, DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import type { Int } from '../../util/numbers.js';
 
@@ -16,8 +16,8 @@ export type ListDeviceAttributeOptions<IKey, IValue> = ListDeviceAttributeOption
 export default class ListDeviceAttribute<
     IKey extends ListDeviceAttributeItem,
     IValue extends ListDeviceAttributeItem,
-    IsSet extends boolean = false,
-> extends DeviceAttribute<IKey, IsSet>
+    IsInitialized extends boolean = false,
+> extends DeviceAttribute<IKey, IsInitialized>
 {
     @Expose({ name: 'values' })
     private _values: ListDeviceAttributeOptions<IKey, IValue>;
@@ -27,7 +27,7 @@ export default class ListDeviceAttribute<
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         values: ListDeviceAttributeOptions<IKey, IValue>,
-        initialValue: AttributeStorage<IKey, IsSet>,
+        initialValue: AttributeValue<IKey, IsInitialized>,
     ) {
         super(name, label, modifier, initialValue);
 

--- a/src/device/attribute/listDeviceAttribute.ts
+++ b/src/device/attribute/listDeviceAttribute.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import type { DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import type { Int } from '../../util/numbers.js';
 
@@ -9,15 +9,15 @@ export type ListDeviceAttributeItem = string | Int;
 export type InitializedListDeviceAttribute<
     IKey extends ListDeviceAttributeItem,
     IValue extends ListDeviceAttributeItem,
-> = ListDeviceAttribute<IKey, IValue, IKey>;
+> = ListDeviceAttribute<IKey, IValue, true>;
 
 export type ListDeviceAttributeOptions<IKey, IValue> = ListDeviceAttributeOption<IKey, IValue>[];
 
 export default class ListDeviceAttribute<
     IKey extends ListDeviceAttributeItem,
     IValue extends ListDeviceAttributeItem,
-    T extends IKey | undefined = IKey | undefined,
-> extends DeviceAttribute<IKey, T>
+    IsSet extends boolean = false,
+> extends DeviceAttribute<IKey, IsSet>
 {
     @Expose({ name: 'values' })
     private _values: ListDeviceAttributeOptions<IKey, IValue>;
@@ -27,7 +27,7 @@ export default class ListDeviceAttribute<
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         values: ListDeviceAttributeOptions<IKey, IValue>,
-        initialValue: T,
+        initialValue: AttributeStorage<IKey, IsSet>,
     ) {
         super(name, label, modifier, initialValue);
 
@@ -41,7 +41,7 @@ export default class ListDeviceAttribute<
         values: ListDeviceAttributeOptions<IKey, IValue>,
         initialValue: IKey,
     ): InitializedListDeviceAttribute<IKey, IValue> {
-        return new ListDeviceAttribute<IKey, IValue, IKey>(
+        return new ListDeviceAttribute<IKey, IValue, true>(
             name, label, modifier, values, initialValue,
         );
     }

--- a/src/device/attribute/numberDeviceAttribute.ts
+++ b/src/device/attribute/numberDeviceAttribute.ts
@@ -1,4 +1,4 @@
-import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeValue, DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import { Expose } from 'class-transformer';
 import type { Float, Int } from '../../util/numbers.js';
@@ -7,8 +7,8 @@ export type NumberAttributeValue = Int | Float;
 
 export default abstract class NumberDeviceAttribute<
     V extends NumberAttributeValue = NumberAttributeValue,
-    IsSet extends boolean = false,
-> extends DeviceAttribute<V, IsSet>
+    IsInitialized extends boolean = false,
+> extends DeviceAttribute<V, IsInitialized>
 {
     @Expose({ name: 'uom' })
     private readonly _uom: string | undefined;
@@ -18,7 +18,7 @@ export default abstract class NumberDeviceAttribute<
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         uom: string | undefined,
-        initialValue: AttributeStorage<V, IsSet>,
+        initialValue: AttributeValue<V, IsInitialized>,
     ) {
         super(name, label, modifier, initialValue);
         this._uom = uom;

--- a/src/device/attribute/numberDeviceAttribute.ts
+++ b/src/device/attribute/numberDeviceAttribute.ts
@@ -27,8 +27,4 @@ export default abstract class NumberDeviceAttribute<
     public get uom(): string | undefined {
         return this._uom;
     }
-
-    public override isValidValue(value: unknown): value is V {
-        return typeof value === 'number';
-    }
 }

--- a/src/device/attribute/numberDeviceAttribute.ts
+++ b/src/device/attribute/numberDeviceAttribute.ts
@@ -1,4 +1,4 @@
-import type { DeviceAttributeModifier } from './deviceAttribute.js';
+import type { AttributeStorage, DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import { Expose } from 'class-transformer';
 import type { Float, Int } from '../../util/numbers.js';
@@ -7,8 +7,8 @@ export type NumberAttributeValue = Int | Float;
 
 export default abstract class NumberDeviceAttribute<
     V extends NumberAttributeValue = NumberAttributeValue,
-    T extends V | undefined = V | undefined,
-> extends DeviceAttribute<V, T>
+    IsSet extends boolean = false,
+> extends DeviceAttribute<V, IsSet>
 {
     @Expose({ name: 'uom' })
     private readonly _uom: string | undefined;
@@ -18,7 +18,7 @@ export default abstract class NumberDeviceAttribute<
         label: string | undefined,
         modifier: DeviceAttributeModifier,
         uom: string | undefined,
-        initialValue: T,
+        initialValue: AttributeStorage<V, IsSet>,
     ) {
         super(name, label, modifier, initialValue);
         this._uom = uom;

--- a/src/device/attribute/numberDeviceAttribute.ts
+++ b/src/device/attribute/numberDeviceAttribute.ts
@@ -1,11 +1,14 @@
-import type { DeviceAttributeModifier, NotJustUndefined, NotUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 import { Expose } from 'class-transformer';
 import type { Float, Int } from '../../util/numbers.js';
 
-export type NumberAttributeValue = NotJustUndefined<Int | Float | undefined>;
+export type NumberAttributeValue = Int | Float;
 
-export default abstract class NumberDeviceAttribute<T extends NumberAttributeValue = NumberAttributeValue> extends DeviceAttribute<T>
+export default abstract class NumberDeviceAttribute<
+    V extends NumberAttributeValue = NumberAttributeValue,
+    T extends V | undefined = V | undefined,
+> extends DeviceAttribute<V, T>
 {
     @Expose({ name: 'uom' })
     private readonly _uom: string | undefined;
@@ -25,7 +28,7 @@ export default abstract class NumberDeviceAttribute<T extends NumberAttributeVal
         return this._uom;
     }
 
-    public override isValidValue(value: unknown): value is NotUndefined<T> {
+    public override isValidValue(value: unknown): value is V {
         return typeof value === 'number';
     }
 }

--- a/src/device/attribute/strDeviceAttribute.ts
+++ b/src/device/attribute/strDeviceAttribute.ts
@@ -1,11 +1,9 @@
 import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 
-type StrDeviceAttributeValue = string | undefined;
+export type InitializedStrDeviceAttribute = StrDeviceAttribute<true>;
 
-export type InitializedStrDeviceAttribute = StrDeviceAttribute<string>;
-
-export default class StrDeviceAttribute<T extends StrDeviceAttributeValue = StrDeviceAttributeValue> extends DeviceAttribute<string, T>
+export default class StrDeviceAttribute<IsSet extends boolean = false> extends DeviceAttribute<string, IsSet>
 {
     public static createInitialized(
         name: string,
@@ -13,14 +11,14 @@ export default class StrDeviceAttribute<T extends StrDeviceAttributeValue = StrD
         modifier: DeviceAttributeModifier,
         initialValue: string,
     ): InitializedStrDeviceAttribute {
-        return new StrDeviceAttribute<string>(name, label, modifier, initialValue);
+        return new StrDeviceAttribute<true>(name, label, modifier, initialValue);
     }
 
     public static create(
         name: string,
         label: string | undefined,
         modifier: DeviceAttributeModifier,
-        initialValue?: StrDeviceAttributeValue,
+        initialValue?: string,
     ): StrDeviceAttribute {
         return new StrDeviceAttribute(name, label, modifier, initialValue);
     }

--- a/src/device/attribute/strDeviceAttribute.ts
+++ b/src/device/attribute/strDeviceAttribute.ts
@@ -1,11 +1,11 @@
-import type { DeviceAttributeModifier, NotJustUndefined, NotUndefined } from './deviceAttribute.js';
+import type { DeviceAttributeModifier } from './deviceAttribute.js';
 import DeviceAttribute from './deviceAttribute.js';
 
-type StrDeviceAttributeValue = NotJustUndefined<string | undefined>;
+type StrDeviceAttributeValue = string | undefined;
 
 export type InitializedStrDeviceAttribute = StrDeviceAttribute<string>;
 
-export default class StrDeviceAttribute<T extends StrDeviceAttributeValue = StrDeviceAttributeValue> extends DeviceAttribute<T>
+export default class StrDeviceAttribute<T extends StrDeviceAttributeValue = StrDeviceAttributeValue> extends DeviceAttribute<string, T>
 {
     public static createInitialized(
         name: string,
@@ -25,13 +25,11 @@ export default class StrDeviceAttribute<T extends StrDeviceAttributeValue = StrD
         return new StrDeviceAttribute(name, label, modifier, initialValue);
     }
 
-    public override fromString(value: string): T {
-        // TODO https://github.com/SlvCtrlPlus/slvctrlplus-server/issues/107
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
-        return value as T;
+    public override fromString(value: string): string {
+        return value;
     }
 
-    public override isValidValue(value: unknown): value is NotUndefined<T> {
+    public override isValidValue(value: unknown): value is string {
         return typeof value === 'string';
     }
 

--- a/src/device/attribute/strDeviceAttribute.ts
+++ b/src/device/attribute/strDeviceAttribute.ts
@@ -3,7 +3,7 @@ import DeviceAttribute from './deviceAttribute.js';
 
 export type InitializedStrDeviceAttribute = StrDeviceAttribute<true>;
 
-export default class StrDeviceAttribute<IsSet extends boolean = false> extends DeviceAttribute<string, IsSet>
+export default class StrDeviceAttribute<IsInitialized extends boolean = false> extends DeviceAttribute<string, IsInitialized>
 {
     public static createInitialized(
         name: string,

--- a/src/device/protocol/buttplugIo/buttplugIoDevice.ts
+++ b/src/device/protocol/buttplugIo/buttplugIoDevice.ts
@@ -3,9 +3,12 @@ import type { ButtplugClientDevice, SensorType } from 'buttplug';
 import { ActuatorType } from 'buttplug';
 import type { AttributeKeyOf, AttributeValueOf, DeviceInfo } from '../../device.js';
 import Device from '../../device.js';
+import type { InitializedIntRangeDeviceAttribute } from '../../attribute/intRangeDeviceAttribute.js';
 import IntRangeDeviceAttribute from '../../attribute/intRangeDeviceAttribute.js';
+import type { InitializedBoolDeviceAttribute } from '../../attribute/boolDeviceAttribute.js';
 import BoolDeviceAttribute from '../../attribute/boolDeviceAttribute.js';
 import { Int } from '../../../util/numbers.js';
+import type { InitializedIntGenericDeviceAttribute } from '../../attribute/intDeviceAttribute.js';
 import IntDeviceAttribute from '../../attribute/intDeviceAttribute.js';
 import { DeviceAttributeModifier } from '../../attribute/deviceAttribute.js';
 import type EventEmitter from 'events';
@@ -18,9 +21,11 @@ type ButtplugSensorTypeKey = `${SensorType}-${number}`;
 
 export type ButtplugIoDeviceAttributeKey = ButtplugActuatorTypeKey | ButtplugSensorTypeKey;
 
+// All attributes are always constructed with an initial value (see buttplugIoDeviceFactory.ts),
+// so they use the Initialized* variants to reflect that at the type level.
 export type ButtplugIoDeviceAttributes = Record<
     ButtplugIoDeviceAttributeKey,
-    IntRangeDeviceAttribute | BoolDeviceAttribute | IntDeviceAttribute | undefined
+    InitializedIntRangeDeviceAttribute | InitializedBoolDeviceAttribute | InitializedIntGenericDeviceAttribute | undefined
 >;
 
 type AttributeValue<K extends keyof ButtplugIoDeviceAttributes> = AttributeValueOf<ButtplugIoDeviceAttributes, K>;
@@ -76,6 +81,10 @@ export default class ButtplugIoDevice extends Device<ButtplugIoDeviceAttributes>
             throw new Error(`Attribute with name '${attributeName}' is readonly`);
         }
 
+        // TypeScript now guarantees `value` is defined for a caller bound by the typed setAttribute
+        // signature above, but this is still reachable via the untyped AnyDevice interface (e.g.
+        // automation scripts), so the runtime guard stays.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (undefined === value) {
             throw new Error(`Value to be set for attribute '${attributeName}' cannot be undefined`);
         }

--- a/src/device/protocol/estim2b/estim2bDevice.ts
+++ b/src/device/protocol/estim2b/estim2bDevice.ts
@@ -1,13 +1,14 @@
 import type { AttributeKeyOf, AttributeValueOf, DeviceInfo } from '../../device.js';
+import type { InitializedIntRangeDeviceAttribute } from '../../attribute/intRangeDeviceAttribute.js';
 import IntRangeDeviceAttribute from '../../attribute/intRangeDeviceAttribute.js';
 import type { Estim2bCommand, EStim2bStatus } from './estim2bProtocol.js';
 import type EStim2bProtocol from './estim2bProtocol.js';
 import { EStim2bMode } from './estim2bProtocol.js';
 import { Exclude, Expose } from 'class-transformer';
 import { Int } from '../../../util/numbers.js';
-import type BoolDeviceAttribute from '../../attribute/boolDeviceAttribute.js';
-import type StrDeviceAttribute from '../../attribute/strDeviceAttribute.js';
-import type ListDeviceAttribute from '../../attribute/listDeviceAttribute.js';
+import type { InitializedBoolDeviceAttribute } from '../../attribute/boolDeviceAttribute.js';
+import type { InitializedStrDeviceAttribute } from '../../attribute/strDeviceAttribute.js';
+import type { InitializedListDeviceAttribute } from '../../attribute/listDeviceAttribute.js';
 import { DeviceAttributeModifier, isValidAttributeValue } from '../../attribute/deviceAttribute.js';
 import type DeviceBidirectionalTransport from '../../transport/deviceBidirectionalTransport.js';
 import PeripheralDevice from '../../peripheralDevice.js';
@@ -15,15 +16,18 @@ import { getErrorFromDecodeResult } from '../deviceProtocol.js';
 import type EventEmitter from 'events';
 import type Logger from '../../../logging/Logger.js';
 
+// All attributes below are always constructed with an initial value (see estim2bDeviceFactory.ts
+// and setModeBasedAttributes()/updateAttributeValues() in this file), so they use the Initialized*
+// variants to reflect that at the type level.
 export type EStim2bDeviceAttributes = {
-    mode: ListDeviceAttribute<Int, string>;
-    channelALevel: IntRangeDeviceAttribute;
-    channelBLevel: IntRangeDeviceAttribute;
-    pulseFrequency?: IntRangeDeviceAttribute;
-    pulsePwm?: IntRangeDeviceAttribute;
-    channelsJoined: BoolDeviceAttribute;
-    highPowerMode: BoolDeviceAttribute;
-    batteryStatus: StrDeviceAttribute;
+    mode: InitializedListDeviceAttribute<Int, string>;
+    channelALevel: InitializedIntRangeDeviceAttribute;
+    channelBLevel: InitializedIntRangeDeviceAttribute;
+    pulseFrequency?: InitializedIntRangeDeviceAttribute;
+    pulsePwm?: InitializedIntRangeDeviceAttribute;
+    channelsJoined: InitializedBoolDeviceAttribute;
+    highPowerMode: InitializedBoolDeviceAttribute;
+    batteryStatus: InitializedStrDeviceAttribute;
 };
 
 export type EStim2bBatteryStatus = 'mains' | 'full' | 'medium' | 'low' | 'critical';
@@ -234,7 +238,7 @@ export default class EStim2bDevice extends PeripheralDevice<EStim2bProtocol, ESt
         };
     }
 
-    private static createPulsePwmAttribute(label: string, currentStatus: EStim2bStatus): IntRangeDeviceAttribute {
+    private static createPulsePwmAttribute(label: string, currentStatus: EStim2bStatus): InitializedIntRangeDeviceAttribute {
         return IntRangeDeviceAttribute.createInitialized(
             'pulsePwm',
             label,
@@ -247,7 +251,7 @@ export default class EStim2bDevice extends PeripheralDevice<EStim2bProtocol, ESt
         );
     }
 
-    private static createPulseFrequencyAttribute(label: string, currentStatus: EStim2bStatus): IntRangeDeviceAttribute {
+    private static createPulseFrequencyAttribute(label: string, currentStatus: EStim2bStatus): InitializedIntRangeDeviceAttribute {
         return IntRangeDeviceAttribute.createInitialized(
             'pulseFrequency',
             label,

--- a/src/device/protocol/virtual/audio/piperVirtualDeviceLogic.ts
+++ b/src/device/protocol/virtual/audio/piperVirtualDeviceLogic.ts
@@ -5,6 +5,7 @@ import type { Readable, Writable } from 'stream';
 import { DeviceAttributeModifier } from '../../../attribute/deviceAttribute.js';
 import StrDeviceAttribute from '../../../attribute/strDeviceAttribute.js';
 import type VirtualDevice from '../virtualDevice.js';
+import type { InitializedBoolDeviceAttribute } from '../../../attribute/boolDeviceAttribute.js';
 import BoolDeviceAttribute from '../../../attribute/boolDeviceAttribute.js';
 import type Logger from '../../../../logging/Logger.js';
 import { spawnProcess } from '../../../../util/process.js';
@@ -29,7 +30,7 @@ type PiperModelMetadata = Static<typeof PiperModelMetadataSchema>;
 
 type PiperVirtualDeviceAttributes = {
     text: StrDeviceAttribute;
-    queuing: BoolDeviceAttribute;
+    queuing: InitializedBoolDeviceAttribute;
 };
 
 export default class PiperVirtualDeviceLogic extends VirtualDeviceLogic<

--- a/src/device/protocol/virtual/audio/ttsVirtualDeviceLogic.ts
+++ b/src/device/protocol/virtual/audio/ttsVirtualDeviceLogic.ts
@@ -3,7 +3,9 @@ import StrDeviceAttribute from '../../../attribute/strDeviceAttribute.js';
 import VirtualDeviceLogic from '../virtualDeviceLogic.js';
 import say from 'say';
 import type VirtualDevice from '../virtualDevice.js';
+import type { InitializedBoolDeviceAttribute } from '../../../attribute/boolDeviceAttribute.js';
 import BoolDeviceAttribute from '../../../attribute/boolDeviceAttribute.js';
+import type { InitializedIntGenericDeviceAttribute } from '../../../attribute/intDeviceAttribute.js';
 import IntDeviceAttribute from '../../../attribute/intDeviceAttribute.js';
 import { Int } from '../../../../util/numbers.js';
 import type Logger from '../../../../logging/Logger.js';
@@ -11,9 +13,9 @@ import type { TtsVirtualDeviceConfig } from './ttsVirtualDeviceConfig.js';
 
 type TtsVirtualDeviceAttributes = {
     text: StrDeviceAttribute;
-    speaking: BoolDeviceAttribute;
-    queuing: BoolDeviceAttribute;
-    queueLength: IntDeviceAttribute;
+    speaking: InitializedBoolDeviceAttribute;
+    queuing: InitializedBoolDeviceAttribute;
+    queueLength: InitializedIntGenericDeviceAttribute;
 };
 
 export default class TtsVirtualDeviceLogic extends VirtualDeviceLogic<

--- a/src/device/protocol/zc95/zc95Device.ts
+++ b/src/device/protocol/zc95/zc95Device.ts
@@ -48,7 +48,7 @@ export type Zc95DevicePowerChannelAttributes = Record<Zc95DevicePowerChannelAttr
 type Zc95DevicePatternAttributesKeyPrefix = `patternAttribute`;
 type Zc95DevicePatternAttributesKey = `${Zc95DevicePatternAttributesKeyPrefix}${number}`;
 
-type Zc95DevicePatternAttributes = Partial<Record<Zc95DevicePatternAttributesKey, InitializedIntRangeDeviceAttribute | ListDeviceAttribute<Int, string>>>;
+type Zc95DevicePatternAttributes = Partial<Record<Zc95DevicePatternAttributesKey, InitializedIntRangeDeviceAttribute | InitializedListDeviceAttribute<Int, string>>>;
 
 export type Zc95DeviceAttributes = AllOrNone<Zc95DevicePowerChannelAttributes> & Zc95DevicePatternAttributes
     & Required<RequiredZc95DeviceAttributes>;
@@ -161,7 +161,7 @@ export default class Zc95Device extends PeripheralDevice<Zc95Protocol, Zc95Devic
             throw new Error('Cannot set channel power before all channel values have been initialized');
         }
 
-        const tmpData: { [K in keyof Zc95DevicePowerChannelAttributes]-?: InitializedIntRangeDeviceAttribute['value'] } = {
+        const tmpData: { [K in keyof Zc95DevicePowerChannelAttributes]-?: Int } = {
             powerChannel1: this.attributes.powerChannel1.value,
             powerChannel2: this.attributes.powerChannel2.value,
             powerChannel3: this.attributes.powerChannel3.value,
@@ -323,7 +323,11 @@ export default class Zc95Device extends PeripheralDevice<Zc95Protocol, Zc95Devic
     }
 
     private static allPowerChannelValuesDefined(attrs: Partial<Zc95DevicePowerChannelAttributes>): attrs is {
-        [K in keyof Zc95DevicePowerChannelAttributes]-?: InitializedIntRangeDeviceAttribute
+        // Power channel attributes are constructed unset (see getChannelPowerAttribute()) and their
+        // value is assigned later, so we can't use InitializedIntRangeDeviceAttribute here (a
+        // different, incompatible instantiation of IntRangeDeviceAttribute) - intersecting with
+        // `{ value: Int }` instead narrows just the value's definedness.
+        [K in keyof Zc95DevicePowerChannelAttributes]-?: Zc95DevicePowerChannelAttributes[K] & { value: Int }
     } {
         return attrs.powerChannel1?.value !== undefined
             && attrs.powerChannel2?.value !== undefined

--- a/tests/type/device/buttplugIo.test-d.ts
+++ b/tests/type/device/buttplugIo.test-d.ts
@@ -4,10 +4,11 @@ import { Int } from '../../../src/util/numbers.js';
 
 declare const device: ButtplugIoDevice;
 
-// any valid actuator/sensor attribute key: Int | boolean | undefined
-expectTypeOf(device.setAttribute('Vibrate-0', Int.from(50))).toEqualTypeOf<Promise<Int | boolean | undefined>>();
-expectTypeOf(device.setAttribute('Rotate-1', true)).toEqualTypeOf<Promise<Int | boolean | undefined>>();
-expectTypeOf(device.setAttribute('Battery-0', undefined)).toEqualTypeOf<Promise<Int | boolean | undefined>>();
+// any valid actuator/sensor attribute key: Int | boolean (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('Vibrate-0', Int.from(50))).toEqualTypeOf<Promise<Int | boolean>>();
+expectTypeOf(device.setAttribute('Rotate-1', true)).toEqualTypeOf<Promise<Int | boolean>>();
+// @ts-expect-error attribute value cannot be undefined
+device.setAttribute('Battery-0', undefined);
 // @ts-expect-error attribute value cannot be a string
 device.setAttribute('Vibrate-0', 'fast');
 

--- a/tests/type/device/estim2b.test-d.ts
+++ b/tests/type/device/estim2b.test-d.ts
@@ -4,32 +4,33 @@ import { Int } from '../../../src/util/numbers.js';
 
 declare const device: EStim2bDevice;
 
-// mode: Int (list attribute key) | undefined
-expectTypeOf(device.setAttribute('mode', Int.from(0))).toEqualTypeOf<Promise<Int | undefined>>();
-expectTypeOf(device.setAttribute('mode', undefined)).toEqualTypeOf<Promise<Int | undefined>>();
+// mode: Int (initialized list attribute, always has a value)
+expectTypeOf(device.setAttribute('mode', Int.from(0))).toEqualTypeOf<Promise<Int>>();
+// @ts-expect-error mode is always initialized and does not accept undefined
+device.setAttribute('mode', undefined);
 // @ts-expect-error mode does not accept a string value
 device.setAttribute('mode', 'bounce');
 
-// channelALevel / channelBLevel: Int | undefined
-expectTypeOf(device.setAttribute('channelALevel', Int.from(50))).toEqualTypeOf<Promise<Int | undefined>>();
-expectTypeOf(device.setAttribute('channelBLevel', Int.from(50))).toEqualTypeOf<Promise<Int | undefined>>();
+// channelALevel / channelBLevel: Int (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('channelALevel', Int.from(50))).toEqualTypeOf<Promise<Int>>();
+expectTypeOf(device.setAttribute('channelBLevel', Int.from(50))).toEqualTypeOf<Promise<Int>>();
 // @ts-expect-error channelALevel does not accept a boolean value
 device.setAttribute('channelALevel', true);
 
-// pulseFrequency / pulsePwm: Int | undefined
-expectTypeOf(device.setAttribute('pulseFrequency', Int.from(10))).toEqualTypeOf<Promise<Int | undefined>>();
-expectTypeOf(device.setAttribute('pulsePwm', Int.from(10))).toEqualTypeOf<Promise<Int | undefined>>();
+// pulseFrequency / pulsePwm: Int (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('pulseFrequency', Int.from(10))).toEqualTypeOf<Promise<Int>>();
+expectTypeOf(device.setAttribute('pulsePwm', Int.from(10))).toEqualTypeOf<Promise<Int>>();
 // @ts-expect-error pulseFrequency does not accept a string value
 device.setAttribute('pulseFrequency', '10');
 
-// channelsJoined / highPowerMode: boolean | undefined
-expectTypeOf(device.setAttribute('channelsJoined', true)).toEqualTypeOf<Promise<boolean | undefined>>();
-expectTypeOf(device.setAttribute('highPowerMode', false)).toEqualTypeOf<Promise<boolean | undefined>>();
+// channelsJoined / highPowerMode: boolean (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('channelsJoined', true)).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(device.setAttribute('highPowerMode', false)).toEqualTypeOf<Promise<boolean>>();
 // @ts-expect-error highPowerMode does not accept an Int value
 device.setAttribute('highPowerMode', Int.from(1));
 
-// batteryStatus: string | undefined
-expectTypeOf(device.setAttribute('batteryStatus', 'mains')).toEqualTypeOf<Promise<string | undefined>>();
+// batteryStatus: string (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('batteryStatus', 'mains')).toEqualTypeOf<Promise<string>>();
 // @ts-expect-error batteryStatus does not accept a boolean value
 device.setAttribute('batteryStatus', true);
 

--- a/tests/type/device/virtual/virtual.test-d.ts
+++ b/tests/type/device/virtual/virtual.test-d.ts
@@ -11,14 +11,14 @@ expectTypeOf(device.setAttribute('text', undefined)).toEqualTypeOf<Promise<strin
 // @ts-expect-error text does not accept an Int value
 device.setAttribute('text', Int.from(1));
 
-// speaking / queuing: boolean | undefined
-expectTypeOf(device.setAttribute('speaking', true)).toEqualTypeOf<Promise<boolean | undefined>>();
-expectTypeOf(device.setAttribute('queuing', false)).toEqualTypeOf<Promise<boolean | undefined>>();
+// speaking / queuing: boolean (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('speaking', true)).toEqualTypeOf<Promise<boolean>>();
+expectTypeOf(device.setAttribute('queuing', false)).toEqualTypeOf<Promise<boolean>>();
 // @ts-expect-error queuing does not accept a string value
 device.setAttribute('queuing', 'yes');
 
-// queueLength: Int | undefined
-expectTypeOf(device.setAttribute('queueLength', Int.from(3))).toEqualTypeOf<Promise<Int | undefined>>();
+// queueLength: Int (initialized attribute, always has a value)
+expectTypeOf(device.setAttribute('queueLength', Int.from(3))).toEqualTypeOf<Promise<Int>>();
 // @ts-expect-error queueLength does not accept a boolean value
 device.setAttribute('queueLength', true);
 

--- a/tests/type/device/zc95/zc95.test-d.ts
+++ b/tests/type/device/zc95/zc95.test-d.ts
@@ -20,8 +20,8 @@ expectTypeOf(device.setAttribute('powerChannel4', Int.from(50))).toEqualTypeOf<P
 // @ts-expect-error powerChannel5 is not a valid power channel index
 device.setAttribute('powerChannel5', Int.from(50));
 
-// patternAttribute<N> (dynamic, numeric suffix): Int | undefined
-expectTypeOf(device.setAttribute('patternAttribute3', Int.from(10))).toEqualTypeOf<Promise<Int | undefined>>();
+// patternAttribute<N> (dynamic, numeric suffix, initialized attribute, always has a value): Int
+expectTypeOf(device.setAttribute('patternAttribute3', Int.from(10))).toEqualTypeOf<Promise<Int>>();
 // @ts-expect-error patternAttribute suffix must be numeric
 device.setAttribute('patternAttributeFoo', Int.from(10));
 

--- a/tests/unit/device/attribute/floatDeviceAttribute.spec.ts
+++ b/tests/unit/device/attribute/floatDeviceAttribute.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import FloatDeviceAttribute from '../../../../src/device/attribute/floatDeviceAttribute.js';
+import { DeviceAttributeModifier } from '../../../../src/device/attribute/deviceAttribute.js';
+
+describe('FloatDeviceAttribute', () => {
+
+    const attribute = FloatDeviceAttribute.create('attrName', undefined, DeviceAttributeModifier.readWrite, undefined);
+
+    it.each([
+        { value: 5.5, expected: true },
+        { value: 0, expected: true },
+        { value: -5.5, expected: true },
+        { value: NaN, expected: false },
+        { value: Infinity, expected: false },
+        { value: -Infinity, expected: false },
+        { value: '5.5', expected: false },
+        { value: true, expected: false },
+    ])('returns $expected for isValidValue($value)', ({ value, expected }) => {
+        expect(attribute.isValidValue(value)).toStrictEqual(expected);
+    });
+});

--- a/tests/unit/device/attribute/intDeviceAttribute.spec.ts
+++ b/tests/unit/device/attribute/intDeviceAttribute.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import IntDeviceAttribute from '../../../../src/device/attribute/intDeviceAttribute.js';
+import { DeviceAttributeModifier } from '../../../../src/device/attribute/deviceAttribute.js';
+
+describe('IntDeviceAttribute', () => {
+
+    const attribute = IntDeviceAttribute.create('attrName', undefined, DeviceAttributeModifier.readWrite, undefined);
+
+    it.each([
+        { value: 5, expected: true },
+        { value: 0, expected: true },
+        { value: -5, expected: true },
+        { value: 1.5, expected: false },
+        { value: NaN, expected: false },
+        { value: Infinity, expected: false },
+        { value: -Infinity, expected: false },
+        { value: '5', expected: false },
+        { value: true, expected: false },
+    ])('returns $expected for isValidValue($value)', ({ value, expected }) => {
+        expect(attribute.isValidValue(value)).toStrictEqual(expected);
+    });
+});

--- a/tests/unit/device/attribute/intRangeDeviceAttribute.spec.ts
+++ b/tests/unit/device/attribute/intRangeDeviceAttribute.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import IntRangeDeviceAttribute from '../../../../src/device/attribute/intRangeDeviceAttribute.js';
+import { DeviceAttributeModifier } from '../../../../src/device/attribute/deviceAttribute.js';
+import { Int } from '../../../../src/util/numbers.js';
+
+describe('IntRangeDeviceAttribute', () => {
+
+    const attribute = IntRangeDeviceAttribute.create(
+        'attrName',
+        undefined,
+        DeviceAttributeModifier.readWrite,
+        undefined,
+        Int.ZERO,
+        Int.from(100),
+        Int.from(1),
+    );
+
+    it.each([
+        { value: 5, expected: true },
+        { value: 0, expected: true },
+        { value: -5, expected: true },
+        { value: 1.5, expected: false },
+        { value: NaN, expected: false },
+        { value: Infinity, expected: false },
+        { value: -Infinity, expected: false },
+        { value: '5', expected: false },
+        { value: true, expected: false },
+    ])('returns $expected for isValidValue($value)', ({ value, expected }) => {
+        expect(attribute.isValidValue(value)).toStrictEqual(expected);
+    });
+});

--- a/tests/unit/device/protocol/buttplugIo/buttplugIoDevice.spec.ts
+++ b/tests/unit/device/protocol/buttplugIo/buttplugIoDevice.spec.ts
@@ -7,6 +7,7 @@ import ButtplugIoDevice, {
     ButtplugIoDeviceAttributes
 } from "../../../../../src/device/protocol/buttplugIo/buttplugIoDevice.js";
 import {DeviceAttributeModifier} from "../../../../../src/device/attribute/deviceAttribute.js";
+import type {AnyDevice} from "../../../../../src/device/device.js";
 import {Int} from "../../../../../src/util/numbers.js";
 import {describe, it, expect} from "vitest";
 import {mock} from "vitest-mock-extended";
@@ -52,7 +53,7 @@ describe('ButtplugIoDevice', () => {
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
         const boolAttrKey: ButtplugIoDeviceAttributeKey = 'Rotate-1';
 
-        const boolAttr = BoolDeviceAttribute.create(boolAttrKey, undefined, DeviceAttributeModifier.readWrite);
+        const boolAttr = BoolDeviceAttribute.createInitialized(boolAttrKey, undefined, DeviceAttributeModifier.readWrite, true);
 
         const device = createDevice(
             buttplugDeviceMock,
@@ -75,7 +76,7 @@ describe('ButtplugIoDevice', () => {
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
 
         const rangeAttrName: ButtplugIoDeviceAttributeKey = 'Vibrate-2';
-        const rangeAttr = IntRangeDeviceAttribute.create(
+        const rangeAttr = IntRangeDeviceAttribute.createInitialized(
             rangeAttrName,
             undefined,
             DeviceAttributeModifier.readWrite,
@@ -83,6 +84,7 @@ describe('ButtplugIoDevice', () => {
             Int.ZERO,
             Int.from(20),
             Int.from(1),
+            Int.ZERO,
         );
 
         const device = createDevice(
@@ -111,7 +113,7 @@ describe('ButtplugIoDevice', () => {
         // Arrange
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
         const boolAttrKey: ButtplugIoDeviceAttributeKey = 'Rotate-1';
-        const boolAttr = BoolDeviceAttribute.create(boolAttrKey, undefined, DeviceAttributeModifier.readWrite);
+        const boolAttr = BoolDeviceAttribute.createInitialized(boolAttrKey, undefined, DeviceAttributeModifier.readWrite, false);
         const device = createDevice(buttplugDeviceMock, {[boolAttrKey]: boolAttr});
 
         // Act
@@ -128,7 +130,7 @@ describe('ButtplugIoDevice', () => {
         // Arrange
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
         const attrKey: ButtplugIoDeviceAttributeKey = 'Vibrate-1';
-        const readOnlyAttr = BoolDeviceAttribute.create(attrKey, undefined, DeviceAttributeModifier.readOnly);
+        const readOnlyAttr = BoolDeviceAttribute.createInitialized(attrKey, undefined, DeviceAttributeModifier.readOnly, false);
         const device = createDevice(buttplugDeviceMock, {[attrKey]: readOnlyAttr});
 
         // Act
@@ -144,7 +146,7 @@ describe('ButtplugIoDevice', () => {
         // Arrange
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
         const sensorAttrKey: ButtplugIoDeviceAttributeKey = 'Battery-1';
-        const attr = BoolDeviceAttribute.create(sensorAttrKey, undefined, DeviceAttributeModifier.readWrite);
+        const attr = BoolDeviceAttribute.createInitialized(sensorAttrKey, undefined, DeviceAttributeModifier.readWrite, false);
         const device = createDevice(buttplugDeviceMock, {[sensorAttrKey]: attr});
 
         // Act
@@ -160,11 +162,16 @@ describe('ButtplugIoDevice', () => {
         // Arrange
         const buttplugDeviceMock = mock<ButtplugClientDevice>();
         const attrKey: ButtplugIoDeviceAttributeKey = 'Vibrate-1';
-        const attr = BoolDeviceAttribute.create(attrKey, undefined, DeviceAttributeModifier.readWrite);
+        const attr = BoolDeviceAttribute.createInitialized(attrKey, undefined, DeviceAttributeModifier.readWrite, false);
         const device = createDevice(buttplugDeviceMock, {[attrKey]: attr});
 
+        // Go through the untyped device interface: this exercises the runtime guard that protects
+        // against callers (e.g. automation scripts) that aren't bound by the typed setAttribute
+        // overload, since TypeScript itself now rejects `undefined` here for a typed attribute.
+        const untypedDevice: AnyDevice = device;
+
         // Act
-        const result = device.setAttribute(attrKey, undefined);
+        const result = untypedDevice.setAttribute(attrKey, undefined);
 
         // Assert
         await expect(result).rejects.toThrow(`Value to be set for attribute '${attrKey}' cannot be undefined`);

--- a/tests/unit/device/protocol/estim2b/estim2bDevice.spec.ts
+++ b/tests/unit/device/protocol/estim2b/estim2bDevice.spec.ts
@@ -49,12 +49,12 @@ describe('EStim2bDevice', () => {
         ];
 
         return {
-            mode: ListDeviceAttribute.create<Int, string>('mode', 'Mode', DeviceAttributeModifier.readWrite, modeOptions),
-            channelALevel: IntRangeDeviceAttribute.create('channelALevel', 'Channel A', DeviceAttributeModifier.readWrite, undefined, Int.ZERO, Int.from(99), Int.from(1)),
-            channelBLevel: IntRangeDeviceAttribute.create('channelBLevel', 'Channel B', DeviceAttributeModifier.readWrite, undefined, Int.ZERO, Int.from(99), Int.from(1)),
-            channelsJoined: BoolDeviceAttribute.create('channelsJoined', 'Channels Joined', DeviceAttributeModifier.readOnly),
-            highPowerMode: BoolDeviceAttribute.create('highPowerMode', 'High Power Mode', DeviceAttributeModifier.readWrite),
-            batteryStatus: StrDeviceAttribute.create('batteryStatus', 'Battery', DeviceAttributeModifier.readOnly),
+            mode: ListDeviceAttribute.createInitialized<Int, string>('mode', 'Mode', DeviceAttributeModifier.readWrite, modeOptions, Int.from(EStim2bMode.pulse)),
+            channelALevel: IntRangeDeviceAttribute.createInitialized('channelALevel', 'Channel A', DeviceAttributeModifier.readWrite, undefined, Int.ZERO, Int.from(99), Int.from(1), Int.ZERO),
+            channelBLevel: IntRangeDeviceAttribute.createInitialized('channelBLevel', 'Channel B', DeviceAttributeModifier.readWrite, undefined, Int.ZERO, Int.from(99), Int.from(1), Int.ZERO),
+            channelsJoined: BoolDeviceAttribute.createInitialized('channelsJoined', 'Channels Joined', DeviceAttributeModifier.readOnly, false),
+            highPowerMode: BoolDeviceAttribute.createInitialized('highPowerMode', 'High Power Mode', DeviceAttributeModifier.readWrite, false),
+            batteryStatus: StrDeviceAttribute.createInitialized('batteryStatus', 'Battery', DeviceAttributeModifier.readOnly, ''),
         };
     }
 

--- a/tests/unit/device/protocol/zc95/zc95Device.spec.ts
+++ b/tests/unit/device/protocol/zc95/zc95Device.spec.ts
@@ -60,8 +60,11 @@ describe('Zc95Device', () => {
     }
 
     function createPowerChannelAttrs(): Zc95DevicePowerChannelAttributes {
-        const makeAttr = (ch: number) =>
-            IntRangeDeviceAttribute.createInitialized(
+        // Power channel attributes are constructed unset in production (see
+        // Zc95Device.getChannelPowerAttribute()) and only get a value once a power status
+        // message has been received, so we mirror that here rather than using createInitialized().
+        const makeAttr = (ch: number) => {
+            const attr = IntRangeDeviceAttribute.create(
                 `powerChannel${ch}`,
                 `Channel ${ch}`,
                 DeviceAttributeModifier.readWrite,
@@ -69,8 +72,10 @@ describe('Zc95Device', () => {
                 Int.ZERO,
                 Int.from(100),
                 Int.from(1),
-                Int.from(10),
             );
+            attr.value = Int.from(10);
+            return attr;
+        };
 
         return {
             powerChannel1: makeAttr(1),
@@ -693,7 +698,7 @@ describe('Zc95Device', () => {
             mockProtocol.decode.mockReturnValue({ message: powerStatusMsg });
 
             const overLimitAttrs = createPowerChannelAttrs();
-            overLimitAttrs.powerChannel1 = IntRangeDeviceAttribute.createInitialized(
+            overLimitAttrs.powerChannel1 = IntRangeDeviceAttribute.create(
                 'powerChannel1',
                 'Channel 1',
                 DeviceAttributeModifier.readWrite,
@@ -701,8 +706,8 @@ describe('Zc95Device', () => {
                 Int.ZERO,
                 Int.from(100),
                 Int.from(1),
-                Int.from(90), // current value 90 was above the new power limit of 70
             );
+            overLimitAttrs.powerChannel1.value = Int.from(90); // current value 90 was above the new power limit of 70
 
             const device = createDevice({
                 activePattern: createActivePatternAttr(),


### PR DESCRIPTION
Closes #107

## Summary

`DeviceAttribute<T>` used a single generic `T` for both "what kind of value" (e.g. `boolean`) and "is it possibly unset" (`| undefined`). Because `T` could theoretically be instantiated narrower than the concrete kind, `fromString()` couldn't return a plain `boolean`/`string`/`Int`/`Float` without an unsafe `as T` assertion.

This implements the **presence-flag** solution from the issue (the stricter of the two proposed designs): `DeviceAttribute<V, IsSet>` splits the value kind (`V`, fixed per subclass) from a boolean `IsSet` flag, and computes the storage/getter/setter type as `IsSet extends true ? V : V | undefined` (`AttributeStorage<V, IsSet>`). `fromString()`/`isValidValue()` operate on the concrete `V`, which TypeScript can verify without assertions. Unlike the simpler `T extends V | undefined` split, this closes the gap where nothing prevented `T` from degenerating to exactly `undefined`.

## Changes

- `deviceAttribute.ts` – base class takes `<V, IsSet>` now; added `BaseAttributeValue` (concrete kinds, no `undefined`) and `AttributeStorage<V, IsSet>`; `AttributeValue` keeps the same public meaning as before; `hasValue()` narrows to `this is { value: V }`
- `boolDeviceAttribute.ts`, `strDeviceAttribute.ts` – `fromString`/`isValidValue` return the concrete type directly, no assertions; `Initialized*` aliases now mean `<true>`
- `numberDeviceAttribute.ts` – shared abstract base for int/float, generic over `V extends Int | Float`
- `intDeviceAttribute.ts`, `floatDeviceAttribute.ts` – `fromString` returns `Int.from(num)`/`Float.from(num)` directly
- `intRangeDeviceAttribute.ts` – same, and fixes a separate pre-existing bug where `parseInt()`'s plain `number` was laundered into the branded `Int` type via `as T`; now uses `Int.from(res)`
- `listDeviceAttribute.ts` – mechanical update to the new base signature; its two `as IKey` assertions remain, since the value kind is chosen by the caller per instance rather than fixed per subclass (documented in the issue as an expected, separate limitation)

Since TypeScript treats two differently-parameterized instantiations of the same generic class as mutually non-assignable once a conditional type makes a parameter measured-invariant, several consumer type declarations that always construct attributes via `createInitialized()` had to move from the bare (unset-only) attribute type to the `Initialized*` variant — this also makes their "always has a value" contract explicit at the type level:

- `EStim2bDeviceAttributes` – all fields always constructed with a value in `estim2bDeviceFactory.ts`
- `ButtplugIoDeviceAttributes` – all attributes always constructed with a value in `buttplugIoDeviceFactory.ts`
- `PiperVirtualDeviceAttributes.queuing`, `TtsVirtualDeviceAttributes.speaking`/`queuing`/`queueLength` – always constructed via `createInitialized()`
- `Zc95DevicePatternAttributes` – always constructed via `createInitialized()`

`Zc95DevicePowerChannelAttributes` keeps its bare (possibly-unset) type since those attributes are genuinely constructed unset and only get a value once a power status message is received; `Zc95Device.allPowerChannelValuesDefined()` narrows via an intersection type (`Attr & { value: Int }`) rather than the `Initialized` alias, since a type predicate's type must stay assignable to its original parameter type.

Tests updated accordingly (factories now use `createInitialized()` to match the stricter production types; one buttplug.io test goes through the untyped `AnyDevice` interface to still exercise the runtime `undefined`-guard, which stays reachable via that erasure boundary; `tests/type/*.test-d.ts` updated to expect the now-narrower `setAttribute()` types for initialized attributes).

## Verification

- `npm run typecheck` – passes
- `npm run lint` – passes (all `consistent-type-assertions`/`no-unsafe-type-assertion` disables gone from bool/str/int/float/intRange; list's two remain as expected)
- `npm test` – 449/449 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Device attributes now clearly distinguish initialized and uninitialized states.
  * Initialized settings and readings provide defined values through the public API, reducing unnecessary `undefined` handling.
  * Attribute parsing and validation now return strongly typed boolean, string, integer, floating-point, and list values.
  * Device protocol definitions consistently expose initialized attributes with appropriate defaults.

* **Tests**
  * Expanded type and runtime coverage for default values, valid assignments, value validation, and rejection of unsupported undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->